### PR TITLE
Align README FFI docs with delta1 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NederAI Delta 1 – AI‑architectuur
 
-Delta 1 is een toekomstbestendige AI‑architectuur waarin de kern bestaat uit een modulaire *Rust*‑monoliet.  De structuur combineert de eenvoud en robuustheid van een monoliet met de flexibiliteit van microservices: **modulaire monolieten** groeperen logische functies in onafhankelijke modules met duidelijke grenzen; dit levert een hoge ontwikkelsnelheid op zonder de complexiteit van gedistribueerde systemen.  Modules zijn losjes gekoppeld en communiceren via een openbaar API, waardoor u later eenvoudig modules kunt extraheren naar afzonderlijke services.  Deployen gebeurt als één eenheid, waardoor de operationele complexiteit laag blijft.
+Delta 1 is een toekomstbestendige AI‑architectuur waarin de kern bestaat uit een modulaire *Rust*‑monoliet.  De structuur combineert de eenvoud en robuustheid van een monoliet met de flexibiliteit van microservices: **modulaire monolieten** groeperen logische functies in onafhankelijke modules met duidelijke grenzen; dit levert een hoge ontwikkelsnelheid op zonder de complexiteit van gedistribueerde systemen.  Modules zijn losjes gekoppeld en communiceren via een openbaar API, waardoor u later eenvoudig modules kunt extraheren naar afzonderlijke services.  Deployen gebeurt als één eenheid, waardoor de operationele complexiteit laag blijft.  De architectuur is expliciet geworteld in Europese waarden zoals privacy‑by‑design, transparantie, menselijke controle en non-discriminatie zodat implementaties aantoonbaar in lijn met GDPR en de aankomende AI-wetgeving blijven.
 
 Rust werd gekozen vanwege de nadruk op geheugen‑ en typeschaarheid: het taalontwerp bevat een *ownership‑based resource management* (OBRM) mechanisme dat resources automatisch vrijgeeft en buffer‑overflows voorkomt.  De compiler elimineert null‑ en dangling pointers.  Rust combineert deze veiligheidsmechanismen met de snelheid van C/C++ dankzij zero‑cost abstractions en statische geheugentoewijzing.  De PHP‑interface maakt gebruik van de **Foreign Function Interface (FFI)**; FFI maakt het mogelijk om functies uit een andere taal aan te roepen.  PHP 7.4 introduceerde de `FFI`‑klasse; door Rust als gedeelde bibliotheek (cdylib) te compileren en een C‑stijl header aan PHP te leveren, kunnen Rust‑functies direct in PHP worden gebruikt.
 
@@ -95,8 +95,12 @@ pub mod api;
 // centraliseer fouttypes
 pub use common::error::DeltaError;
 
-// herexporteer publieke functies voor FFI/HTTP
-pub use api::ffi::{data_ingest, train_model, run_inference};
+// herexporteer kernfuncties voor interne consumers
+pub use data::service::ingest_file as core_data_ingest;
+pub use inference::service::infer as core_infer;
+pub use training::service::{load_model, train};
+
+// FFI-functies leven onder `api::ffi::{delta1_*}` en vormen de C-ABI grens richting PHP.
 ```
 
 ### Domeinmodules
@@ -115,16 +119,51 @@ Exporteert domeinfuncties via C‑ABI.  Functies gebruiken FFI‑veilige types e
 
 ```rust
 use std::ffi::{CStr, CString};
-use crate::data;
+use std::os::raw::c_char;
+
+use crate::data::service;
+use crate::inference::service as inference_service;
+use crate::training::domain::ModelId;
+use crate::training::service as training_service;
 
 #[no_mangle]
-pub extern "C" fn data_ingest(path: *const c_char) -> u32 {
-    let cstr = unsafe { CStr::from_ptr(path) };
-    let filename = cstr.to_str().unwrap_or_default();
-    match data::ingest_file(filename) {
-        Ok(id) => id,
+pub extern "C" fn delta1_data_ingest(path: *const c_char, schema: *const c_char) -> u32 {
+    if path.is_null() || schema.is_null() {
+        return 0;
+    }
+
+    let path = unsafe { CStr::from_ptr(path) }.to_string_lossy().into_owned();
+    let schema = unsafe { CStr::from_ptr(schema) }.to_string_lossy().into_owned();
+    match service::ingest_file(&path, &schema) {
+        Ok(id) => id.raw(),
         Err(_) => 0,
     }
+}
+
+#[no_mangle]
+pub extern "C" fn delta1_infer(model_id: u32, input: *const c_char) -> *const c_char {
+    if input.is_null() {
+        return std::ptr::null();
+    }
+
+    let payload = unsafe { CStr::from_ptr(input) }.to_string_lossy().into_owned();
+    let model = match training_service::load_model(ModelId::new(model_id)) {
+        Ok(model) => model,
+        Err(_) => return CString::new("{\"ok\":false}").unwrap().into_raw(),
+    };
+
+    match inference_service::infer(&model, &payload) {
+        Ok(prediction) => CString::new(prediction.json).unwrap().into_raw(),
+        Err(_) => CString::new("{\"ok\":false}").unwrap().into_raw(),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn delta1_free_str(ptr: *const c_char) {
+    if ptr.is_null() {
+        return;
+    }
+    unsafe { let _ = CString::from_raw(ptr as *mut c_char); }
 }
 ```
 
@@ -139,26 +178,35 @@ Het `#[no_mangle]` attribuut voorkomt name mangling zodat PHP de functie correct
 ```php
 <?php
 $ffi = FFI::cdef(
-    "unsigned int data_ingest(const char* path);
-     unsigned int train_model(unsigned int dataset_id, const char* config);
-     const char* run_inference(unsigned int model_id, const char* input);",
+    "unsigned int delta1_api_version(void);
+     unsigned int delta1_data_ingest(const char* path, const char* schema_json);
+     unsigned int delta1_train(unsigned int dataset_id, const char* config_json);
+     const char*  delta1_infer(unsigned int model_id, const char* input_json);
+     void         delta1_free_str(const char* ptr);",
     __DIR__ . '/../rust-core/target/release/libdelta1.so'
 );
 
-function delta1_ingest(string $path): int {
-    return $GLOBALS['ffi']->data_ingest($path);
+function delta1_api_version(): int {
+    return $GLOBALS['ffi']->delta1_api_version();
+}
+function delta1_data_ingest(string $path, string $schemaJson): int {
+    return $GLOBALS['ffi']->delta1_data_ingest($path, $schemaJson);
 }
 function delta1_train(int $datasetId, string $configJson): int {
-    return $GLOBALS['ffi']->train_model($datasetId, $configJson);
+    return $GLOBALS['ffi']->delta1_train($datasetId, $configJson);
 }
-function delta1_infer(int $modelId, string $input): string {
-    $cstr = $GLOBALS['ffi']->run_inference($modelId, $input);
-    return FFI::string($cstr);
+function delta1_infer(int $modelId, string $inputJson): string {
+    $ptr = $GLOBALS['ffi']->delta1_infer($modelId, $inputJson);
+    try {
+        return FFI::string($ptr);
+    } finally {
+        $GLOBALS['ffi']->delta1_free_str($ptr);
+    }
 }
 ?>
 ```
 
-FFI maakt het mogelijk functies uit een andere taal aan te roepen, en PHP 7.4 voegde hiervoor de `FFI`‑klasse toe.
+FFI maakt het mogelijk functies uit een andere taal aan te roepen, en PHP 7.4 voegde hiervoor de `FFI`‑klasse toe.  In productiegebruik wordt `FFI::load()` met een vooraf goedgekeurde header aangeraden zodat alleen whitelisted symbolen beschikbaar zijn.
 
 ### `DataService.php`
 
@@ -166,7 +214,7 @@ FFI maakt het mogelijk functies uit een andere taal aan te roepen, en PHP 7.4 vo
 <?php
 class DataService {
     public function importCsv(string $path): int {
-        return delta1_ingest($path);
+        return delta1_data_ingest($path, '{"type":"csv"}');
     }
     public function train(array $config): int {
         $json = json_encode($config);
@@ -195,12 +243,14 @@ Een PDO‑wrapper die named parameters gebruikt om SQL‑injecties te voorkomen.
 
 4. **Rust‑ontwikkeling** – profiteer van Rusts geheugenveiligheid en prestaties; code compileert naar meerdere platforms.
 
-5. **PHP‑FFI interface** – compileer de Rust‑kern als cdylib, exporteer functies met `#[no_mangle] extern "C"` en roep ze aan via `FFI::cdef()`.
+5. **PHP‑FFI interface** – compileer de Rust‑kern als cdylib, exporteer `delta1_*` functies met `#[no_mangle] extern "C"` en roep ze tijdens ontwikkeling aan via `FFI::cdef()`.  In productie gebruik je `FFI::load()` met een statische header zodat uitsluitend goedgekeurde symbolen toegankelijk zijn.
 
 6. **Geen frameworks** – gebruik de standaardbibliotheek en minimaliseer afhankelijkheden.  In PHP wordt geen framework gebruikt; een eventuele HTTP‑router wordt handmatig gebouwd.
 
-7. **Tests en CI** – schrijf unit‑ en integratietests voor zowel Rust‑ als PHP‑lagen; gebruik CI om cdylibs te bouwen en tests te draaien.
+7. **Borg Europese waarden** – ontwerp dataschema’s en modellen privacy‑vriendelijk, voer systematisch fairness‑ en bias-checks uit en documenteer beslissingen zodat menselijke controle en uitlegbaarheid behouden blijven.
 
-8. **Uitbreidbaarheid** – modules kunnen later als microservices worden uitgelicht dankzij hun duidelijke grenzen.
+8. **Tests en CI** – schrijf unit‑ en integratietests voor zowel Rust‑ als PHP‑lagen; gebruik CI om cdylibs te bouwen en tests te draaien.
+
+9. **Uitbreidbaarheid** – modules kunnen later als microservices worden uitgelicht dankzij hun duidelijke grenzen.
 
 ---


### PR DESCRIPTION
## Summary
- highlight that the architecture description is grounded in European values such as privacy, transparency, and non-discrimination
- update the Rust FFI examples to use the `delta1_*` symbols and show correct string ownership handling
- refresh the PHP bootstrap and service snippets to free Rust strings properly and refer to the delta1 API naming, including production guidance for `FFI::load()`

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d1928b12fc8322901b86c416dfb84e