### PR TITLE
Update documentation to match current FFI and module design

### DIFF
--- a/docs/rust-core.md
+++ b/docs/rust-core.md
@@ -1,13 +1,17 @@
 # Delta 1 — Rust Core Architectuur
 
-> Modulaire monoliet in *pure std Rust* (geen frameworks of externe crates). Stabiliteit via een smalle, C-ABI FFI-laag. Sterke grenzen per domein, zero-copy waar mogelijk, en eenvoudige, testbare componenten.
+> Samenvatting van de actuele stand van de crate `rust-core/`. Deze beschrijving
+> volgt de concrete code zodat ontwerpbeslissingen en documentatie synchroon
+> blijven. Alle voorbeelden zijn dependency-vrij (alleen `std`).
 
 ---
 
-## 1. Scope & Doelstellingen
+## 1. Scope & doelstellingen
 
-* **Scope**: `rust-core/` (library `cdylib`) met domeinen `data`, `training`, `inference`, `evaluation`, ondersteund door `common` en een dunne `api::ffi` laag.
-* **Doelen**: deterministisch, memory-safe, minimale dependencies (alleen std), stabiele ABI, hoge performance, eenvoudige observability, EU-conforme privacy/veiligheid.
+* **Scope**: `rust-core/` (`cdylib`) met domeinen `data`, `training`, `inference`,
+  `evaluation`, ondersteund door `common` en de `api::ffi`-laag.
+* **Doelen**: determinisme, memory-safety, stabiele C-ABI, auditbare governance,
+  zo min mogelijk externe dependencies.
 
 ---
 
@@ -16,369 +20,363 @@
 ```
 rust-core/
 └── src/
-    ├── lib.rs                 # orchestrator, re-exports
-    ├── common/
+    ├── lib.rs                 # orchestrator, re-exports (`core_*` helpers)
+    ├── api/
     │   ├── mod.rs
-    │   ├── error.rs           # DeltaError, DeltaCode
-    │   ├── config.rs          # ENV/kv-config
-    │   ├── time.rs            # klokhelpers, monotonic timing
-    │   ├── log.rs             # lichte JSON logging (stdout/stderr)
-    │   ├── buf.rs             # eenvoudige buffer/arena hulpen
-    │   └── ids.rs             # id/hash helpers
+    │   └── ffi.rs             # #[no_mangle] extern "C" functies
+    ├── common/
+    │   ├── buf.rs             # eenvoudige bufferhulpen
+    │   ├── config.rs          # AppCfg::load() (ENV)
+    │   ├── error.rs           # DeltaError + DeltaCode (0..5)
+    │   ├── ids.rs             # SimpleHash helpers
+    │   ├── json.rs            # minimale JSON utils
+    │   ├── log.rs             # log_json() → JSONL
+    │   └── time.rs            # monotone klok
     ├── data/
     │   ├── mod.rs
-    │   ├── domain.rs          # Dataset, Schema
-    │   ├── service.rs         # ingest, validate, normalize
-    │   └── repo_fs.rs         # fs-gebaseerde opslag (std::fs)
+    │   ├── domain.rs          # DatasetId, Dataset, DataRepo
+    │   ├── service.rs         # ingest_file(), export_datasheet()
+    │   └── repo_fs.rs         # scaffolding voor FS-opslag
     ├── training/
     │   ├── mod.rs
-    │   ├── domain.rs          # ModelVersion, TrainConfig
-    │   ├── service.rs         # train(), versioneer, materialiseer
-    │   └── repo_fs.rs         # artefact-IO (bin blobs)
+    │   ├── domain.rs          # ModelId, TrainConfig, metadata
+    │   ├── service.rs         # train(), load_model(), export_model_card()
+    │   └── repo_fs.rs         # artefact IO (placeholder)
     ├── inference/
     │   ├── mod.rs
-    │   ├── domain.rs          # routes, thresholds
-    │   ├── service.rs         # infer(), batch_infer()
-    │   └── workers.rs         # lichtgewicht worker-pool (std::thread/mpsc)
-    ├── evaluation/
-    │   ├── mod.rs
-    │   ├── domain.rs          # EvalSuite, DriftStats
-    │   └── service.rs         # evaluate(), drift()
-    └── api/
+    │   ├── domain.rs          # routing, consent, Prediction
+    │   ├── service.rs         # register_active_model(), infer_with_ctx()
+    │   └── workers.rs         # threadpool (std::thread + mpsc)
+    └── evaluation/
         ├── mod.rs
-        └── ffi.rs             # #[no_mangle] extern "C"
+        ├── domain.rs          # EvalSuite, DriftStats
+        └── service.rs         # evaluate(), drift() (stub)
 ```
 
 ---
 
-## 3. Cross-module contracten (interne traits)
+## 3. Cross-module contracten
 
-> Geen runtime DI; compile-time grenzen via traits en `pub(crate)`.
+Alle domeinen delen compacte types en traits:
 
 ```rust
 // data/domain.rs
-pub struct DatasetId(pub u32);
-pub struct Dataset { pub id: DatasetId, pub schema_json: String, pub created_ms: u128 }
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct DatasetId(String); // stringwrapper (ds-<hash>)
+
+pub struct Dataset {
+    pub id: DatasetId,
+    pub schema: Schema,
+    pub created_ms: u128,
+    pub rows: u64,
+}
 
 pub trait DataRepo {
-    fn put_dataset(&self, d: &Dataset) -> Result<(), DeltaError>;
-    fn get_dataset(&self, id: DatasetId) -> Result<Dataset, DeltaError>;
+    fn put_dataset(&self, dataset: &Dataset) -> DeltaResult<()>;
+    fn get_dataset(&self, id: DatasetId) -> DeltaResult<Dataset>;
 }
 
 // training/domain.rs
-pub struct ModelId(pub u32);
-pub struct ModelVersion { pub id: ModelId, pub version: String, pub artefact_path: String }
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct ModelId(String);
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct VersionName(String);
+
+pub struct ModelVersion {
+    pub id: ModelId,
+    pub version: VersionName,
+    pub kind: ModelKind,
+    pub artefact_path: String,
+    pub metadata: ModelMetadata,
+}
 
 pub trait ModelRepo {
-    fn put_model(&self, m: &ModelVersion) -> Result<(), DeltaError>;
-    fn get_model(&self, id: ModelId) -> Result<ModelVersion, DeltaError>;
+    fn put_model(&self, model: &ModelVersion) -> DeltaResult<()>;
+    fn get_model(&self, id: &ModelId, version: &VersionName)
+        -> DeltaResult<ModelVersion>;
 }
 
 // inference/domain.rs
-pub struct Prediction { pub json: String, pub latency_ms: u32, pub confidence: f32 }
+pub struct Prediction {
+    pub json: String,
+    pub latency_ms: u32,
+    pub confidence: f32,
+    pub whylog: WhyLog,
+}
+
 pub trait InferEngine {
-    fn infer(&self, model: &ModelVersion, input_json: &str) -> Result<Prediction, DeltaError>;
+    fn kind(&self) -> RouteTarget;
+    fn infer(&self, model: &ModelVersion, input_json: &str)
+        -> DeltaResult<EngineResponse>;
 }
 ```
-
-Implementaties zitten in `repo_fs.rs` en `service.rs`. `lib.rs` composeert concrete structen en stelt alleen *smalle* façade-functies publiek.
 
 ---
 
 ## 4. Foutafhandeling
 
-* Eén type: `DeltaError` + numerieke `DeltaCode` (stabiele mapping voor FFI).
-* Geen panics over modulegrenzen; alles via `Result<_, DeltaError>`.
+`common/error.rs` definieert de stabiele errorcodes die over de C-ABI gaan:
 
 ```rust
-// common/error.rs
 #[repr(u32)]
-#[derive(Copy, Clone)]
-pub enum DeltaCode { Ok=0, InvalidInput=10, Io=20, NotFound=30, Internal=50 }
+pub enum DeltaCode {
+    Ok = 0,
+    NoConsent = 1,
+    PolicyDenied = 2,
+    ModelMissing = 3,
+    InvalidInput = 4,
+    Internal = 5,
+}
 
-pub struct DeltaError { pub code: DeltaCode, pub msg: &'static str }
-
-impl DeltaError {
-    pub fn io() -> Self { Self{ code:DeltaCode::Io, msg:"io" } }
-    pub fn invalid(m:&'static str)->Self{ Self{code:DeltaCode::InvalidInput,msg:m} }
+pub struct DeltaError {
+    pub code: DeltaCode,
+    pub msg: &'static str,
 }
 ```
 
+Helpers zoals `DeltaError::policy_denied("dp_epsilon_exceeded")` of
+`DeltaError::invalid("ffi_null")` worden consequent gebruikt in alle services.
+`api::ffi` vertaalt errors naar `i32` zodat PHP eenvoudig kan inspecteren.
+
 ---
 
-## 5. Configuratie (zonder externe parser)
+## 5. Configuratie
 
-* Bron: **ENV** variabelen en optioneel `key=value` bestand (eenvoudig, line-based).
-* Immutable runtime snapshot.
+`common/config.rs` laadt omgevingsvariabelen zonder externe parser:
 
 ```rust
-// common/config.rs
-pub struct AppCfg {
-    pub data_root: String,      // bv. /var/delta1
-    pub region:    String,      // bv. eu-west
-    pub log_level: u8,          // 0=error..3=debug
-}
-pub fn load_cfg() -> AppCfg {
-    fn env(k:&str, d:&str)->String { std::env::var(k).unwrap_or_else(|_| d.into()) }
-    AppCfg {
-        data_root: env("DELTA1_DATA_ROOT", "./data"),
-        region:    env("DELTA1_REGION",    "eu"),
-        log_level: env("DELTA1_LOG_LEVEL", "1").parse().unwrap_or(1),
+impl AppCfg {
+    pub fn load() -> Self {
+        fn env_or(key: &str, default: &str) -> String {
+            std::env::var(key).unwrap_or_else(|_| default.to_string())
+        }
+        Self {
+            data_root: env_or("DELTA1_DATA_ROOT", "./data"),
+            region: env_or("DELTA1_REGION", "eu"),
+            log_level: env_or("DELTA1_LOG_LEVEL", "1").parse().unwrap_or(1),
+        }
     }
 }
 ```
 
+`lib.rs` biedt een `load_cfg()`-wrapper voor achterwaartse compatibiliteit met de
+oude documentatie.
+
 ---
 
-## 6. Logging & Observability (lichtgewicht)
+## 6. Logging & observability
 
-* JSON-regels naar stdout; geen lock-contentie door korte, geformatteerde strings.
-* Korrel: module/event, duur, code.
+`common/log.rs` schrijft compacte JSON-regels naar stdout:
 
 ```rust
-// common/log.rs
-pub fn log_json(level:&str, module:&str, event:&str, code:u32, dur_ms:u128) {
+pub fn log_json(level: &str, module: &str, event: &str, code: u32, dur_ms: u128) {
     let ts = crate::common::time::now_ms();
-    println!("{{\"ts\":{ts},\"level\":\"{level}\",\"mod\":\"{module}\",\"ev\":\"{event}\",\"code\":{code},\"dur_ms\":{dur_ms}}}");
+    println!(
+        "{{\"ts\":{ts},\"level\":\"{level}\",\"mod\":\"{module}\",\"ev\":\"{event}\",\"code\":{code},\"dur_ms\":{dur_ms}}}"
+    );
 }
 ```
+
+Metrics zoals `infer_latency_ms` of `train_dur_ms` worden later toegevoegd; de
+logstructuur is alvast stabiel.
 
 ---
 
 ## 7. Concurrency-model
 
-* CPU-bound taken: *worker-pool* in `inference/workers.rs` met `std::sync::mpsc`.
-* IO-bound: synchrone std IO, backpressure via queue-lengte.
-* Geen globale mutable state; gedeelde structen via `Arc<...>` + `Mutex/RwLock` alleen waar strikt nodig.
+Alle concurrency bouwt op `std`:
 
 ```rust
 // inference/workers.rs
 pub struct Pool {
-    tx: std::sync::mpsc::Sender<Box<dyn FnOnce() + Send + 'static>>
+    tx: mpsc::Sender<Box<dyn FnOnce() + Send + 'static>>,
 }
+
 impl Pool {
-    pub fn new(n:usize)->Self{
-        let (tx, rx)=std::sync::mpsc::channel::<Box<dyn FnOnce()+Send>>();
-        for _ in 0..n {
-            let rx=rx.clone();
-            std::thread::spawn(move || while let Ok(job)=rx.recv(){ job(); });
-        }
-        Self{tx}
+    pub fn new(size: usize) -> Self { /* spawns std::thread workers */ }
+    pub fn submit<F>(&self, job: F)
+    where F: FnOnce() + Send + 'static,
+    {
+        let _ = self.tx.send(Box::new(job));
     }
-    pub fn submit<F:FnOnce()+Send+'static>(&self, f:F){ let _=self.tx.send(Box::new(f)); }
 }
 ```
 
+`inference::service` gebruikt momenteel synchrone paden; de worker-pool staat klaar
+voor CPU-intensieve taken wanneer echte modellen worden aangesloten.
+
 ---
 
-## 8. Data-pad (minimalistisch)
+## 8. Data-pad
 
-* **Ingest**: lees bestand in streaming modus (`BufRead::lines()`), simpele CSV/JSON-heuristiek, schema-check (veldnamen/typen zoals gedeclareerd in `schema_json`).
-* **Normalize**: trimming, lowercasing waar passend, PII-strategieën (hash/pseudonymize) voordat iets wordt opgeslagen op disk.
-* **Opslag**: metadata in eenvoudige `*.meta` bestanden (line-based of mini-JSON) + datahash als sleutelnaam.
+`data::service::ingest_file` leest bestanden streaming met `BufRead::read_line`:
 
 ```rust
-// data/service.rs (schets)
-pub fn ingest_file(path:&str, schema_json:&str) -> Result<DatasetId, DeltaError> {
-    use std::{fs::File, io::{BufRead,BufReader}};
-    let f = File::open(path).map_err(|_| DeltaError::io())?;
-    let mut rdr = BufReader::new(f);
-    let mut hasher = crate::common::ids::SimpleHash::new();
-    let mut count = 0u64;
+pub fn ingest_file(path: &str, schema_json: &str) -> DeltaResult<DatasetId> {
+    let file = File::open(Path::new(path)).map_err(|_| DeltaError::io())?;
+    let mut reader = BufReader::new(file);
+    let mut hasher = SimpleHash::new();
     let mut line = String::new();
-    while rdr.read_line(&mut line).map_err(|_|DeltaError::io())? > 0 {
-        hasher.update(line.as_bytes()); // normalisatie kan hier
-        count += 1; line.clear();
+    let mut rows = 0u64;
+
+    loop {
+        line.clear();
+        if reader.read_line(&mut line).map_err(|_| DeltaError::io())? == 0 {
+            break;
+        }
+        hasher.update(line.as_bytes());
+        rows += 1;
     }
-    let id = DatasetId(hasher.finish32());
-    // schrijf meta naar {data_root}/datasets/{id}.meta
-    // ...
-    Ok(id)
+
+    let dataset_id = DatasetId::new(format!("ds-{}", hasher.finish_hex()));
+    let _dataset = Dataset::new(dataset_id.clone(), schema_json.to_string(),
+                                time::now_ms(), rows);
+    Ok(dataset_id)
 }
 ```
 
+`export_datasheet` levert alvast een JSON-placeholder met `retention_days`.
+Persistente opslag (`DataRepo`) volgt later.
+
 ---
 
-## 9. Train-pad (std-only)
+## 9. Training-pad
 
-> *Opzettelijk eenvoudig*: we modelleren training als transformatie van dataset → artefact (binaire blob). De “ML” kan later achter FFI worden gehaakt; hier gaat het om lifecycle & versiebeheer.
-
-* `TrainConfig`: hyperparameters als mini-JSON string (gemaakt in PHP; parsing in Rust enkel wat we nodig hebben via eenvoudige substring/number-extractie om externe JSON te vermijden).
-* Artefact: binaire file `{models}/{id}-{version}.bin` met header (magic, versie, checksum).
+`training::service::train` verwerkt DP- en fairness-gates voordat een model wordt
+opgeslagen in een in-memory registry:
 
 ```rust
-// training/service.rs (schets)
-pub fn train(dataset: DatasetId, cfg_json:&str) -> Result<ModelId, DeltaError> {
-    // 1) laad dataset meta/gegevens
-    // 2) simuleer “training”: produceer deterministische bytes o.b.v. seed
-    // 3) schrijf artefact + modelkaart (.card)
-    Ok(ModelId( /* hash */ 1 ))
+pub fn train(dataset: DatasetId, cfg_json: &str) -> DeltaResult<ModelVersion> {
+    let cfg = TrainConfig::parse(cfg_json.to_string())?;
+    enforce_dp(&cfg)?;
+    enforce_fairness(&cfg)?;
+
+    let model_id = make_model_id(&dataset, cfg_json, cfg.model_kind());
+    let version = VersionName::new(format!("v{}", time::now_ms()));
+    let artefact_path = format!("models/{}/{}/model.bin", model_id.as_str(), version.as_str());
+
+    let model = ModelVersion { /* metadata inclusief DP/fairness */ };
+    registry().lock()?.insert(model.clone());
+    Ok(model)
 }
 ```
 
+`export_model_card` projecteert DP- en fairnessmetadata naar JSON zodat PHP deze
+kan aanbieden aan auditors. `load_model` haalt de laatste of gevraagde versie op en
+wordt door `api::ffi::delta1_load_model` gebruikt om het actieve model te registreren.
+
 ---
 
-## 10. Infer-pad
+## 10. Inferentie
 
-* Laad `ModelVersion` → `InferEngine::infer()` → retourneer `Prediction` met JSON-string (manueel geformatteerd om geen externe JSON-lib te gebruiken).
-* Batch-variant accepteert array-input in één call voor throughput.
+`inference::service::infer_with_ctx` bundelt consent, routering en engine-calls:
 
 ```rust
-// inference/service.rs (schets)
-pub fn infer(model: &ModelVersion, input_json:&str) -> Result<Prediction, DeltaError> {
-    let start=crate::common::time::now_ms();
-    // dummy: echo input met stub confidence
-    let out = format!("{{\"ok\":true,\"model\":\"{}\",\"y\":null}}", model.version);
-    let dur = (crate::common::time::now_ms() - start) as u32;
-    Ok(Prediction{ json: out, latency_ms: dur, confidence: 0.5 })
+pub fn infer_with_ctx(purpose: &str, subject: &str, input_json: &str)
+    -> DeltaResult<Prediction>
+{
+    let model = active_model().ok_or_else(|| DeltaError::model_missing("active_model"))?;
+    let context = build_context(purpose, subject, input_json);
+    ensure_consent(consent_store(), &context)?; // huidige implementatie: allow-all
+
+    let router_ctx = RouterContext::from_payload(input_json, &context);
+    let decision = ensure_compatible(&model, router().route(&router_ctx));
+
+    let start = time::now_ms();
+    let response = match engines().infer(decision.target, &model, input_json) {
+        Ok(resp) => resp,
+        Err(err) if decision.target == RouteTarget::Text => {
+            engines().infer(RouteTarget::Tabular, &model, input_json)?
+        }
+        Err(err) => return Err(err),
+    };
+    let latency = time::now_ms().saturating_sub(start) as u32;
+
+    let mut body = merge_payload(&response.payload, &model, decision, response.confidence);
+    let whylog = build_whylog(&body, &response);
+    append_whylog_hash(&mut body, &whylog.hash);
+
+    Ok(Prediction { json: body, latency_ms: latency, confidence: response.confidence, whylog })
 }
 ```
 
----
-
-## 11. Evaluatie & Drift
-
-* Evaluatie produceert compacte rapporten (`metrics.card`, `bias.card`) met kerncijfers (AUC/F1 worden hier als placeholders berekend met eenvoudige tellers).
-* Drift: simpele PSI/KS-benadering op basis van histogrammen die tijdens inferentie worden geaccumuleerd (in geheugen, periodiek flush naar disk).
+Tekstpaden die falen vallen terug naar tabular (`RouteTarget::Tabular`). Elke
+respons bevat `whylog_hash`, `route`, `confidence` en `model_id`.
 
 ---
 
-## 12. FFI-grens (ABI-stabiel)
+## 11. Evaluatie
 
-* Alleen **POD** types over de grens: `u32`, `*const c_char`.
-* Strings richting PHP: gealloceerd via `CString::into_raw()`, vrijgave via `delta1_free_str`.
+`evaluation::service` bevat placeholderfuncties:
 
 ```rust
-// api/ffi.rs
-use std::os::raw::c_char;
-use std::ffi::{CStr, CString};
+pub fn evaluate(model: &ModelVersion) -> DeltaResult<EvalSuite> {
+    Ok(EvalSuite { model: model.clone(), metrics_card: "{}".into() })
+}
 
-#[no_mangle] pub extern "C" fn delta1_api_version()->u32 { 1 }
+pub fn drift(model: &ModelVersion) -> DeltaResult<DriftStats> {
+    Err(DeltaError::not_implemented("evaluation::service::drift"))
+}
+```
 
+De structuren zijn aanwezig zodat latere implementaties (metrics, PSI/KS) direct
+kunnen inhaken.
+
+---
+
+## 12. FFI-contract
+
+`api::ffi` vormt de stabiele grens voor PHP. Kernfuncties:
+
+```rust
 #[no_mangle]
-pub extern "C" fn delta1_data_ingest(path:*const c_char, schema:*const c_char)->u32{
-    let p = unsafe{ CStr::from_ptr(path) }.to_string_lossy();
-    let s = unsafe{ CStr::from_ptr(schema) }.to_string_lossy();
-    match crate::data::service::ingest_file(&p, &s){ Ok(id)=>id.0, Err(_)=>0 }
-}
-
+pub extern "C" fn delta1_api_version() -> *const c_char { /* "1.0.0" */ }
 #[no_mangle]
-pub extern "C" fn delta1_infer(model_id:u32, input:*const c_char)->*const c_char{
-    let inp = unsafe{ CStr::from_ptr(input) }.to_string_lossy();
-    let mv = crate::training::service::load_model(ModelId(model_id)).unwrap();
-    let out = crate::inference::service::infer(&mv, &inp)
-        .map(|p| p.json).unwrap_or_else(|_| "{\"ok\":false}".into());
-    CString::new(out).unwrap().into_raw()
-}
-
+pub extern "C" fn delta1_data_ingest(filepath: *const c_char, out_dataset_id: *mut *const c_char) -> i32;
 #[no_mangle]
-pub extern "C" fn delta1_free_str(ptr:*const c_char){
-    if ptr.is_null(){return;}
-    unsafe{ let _ = CString::from_raw(ptr as *mut c_char); }
-}
+pub extern "C" fn delta1_train(dataset_id: *const c_char,
+                                 train_cfg_json: *const c_char,
+                                 out_model_id: *mut *const c_char) -> i32;
+#[no_mangle]
+pub extern "C" fn delta1_load_model(model_id: *const c_char, version: *const c_char) -> i32;
+#[no_mangle]
+pub extern "C" fn delta1_infer_with_ctx(purpose_id: *const c_char,
+                                          subject_id: *const c_char,
+                                          input_json: *const c_char) -> *const c_char;
+#[no_mangle]
+pub extern "C" fn delta1_export_model_card(model_id: *const c_char) -> *const c_char;
+#[no_mangle]
+pub extern "C" fn delta1_export_datasheet(dataset_id: *const c_char) -> *const c_char;
+#[no_mangle]
+pub extern "C" fn delta1_free_str(ptr: *const c_char);
 ```
 
----
-
-## 13. Geheugen & Zero-copy Richtlijnen
-
-* Geef voorkeur aan `&[u8]`/`&str` boven `Vec` waar mogelijk.
-* Hergebruik buffers (zie `common::buf`) voor I/O-loops.
-* Vermijd onnodige klonen; gebruik `Cow` niet (std-only), dus handmatig met slices werken.
-* In FFI: *alleen* één keer alloceren aan de Rust-kant; call-site in PHP *moet* vrijgeven.
+* Returnwaarden (`i32`) zijn `DeltaCode`-waarden.
+* `assign_out_string()` en `string_to_raw()` zorgen voor veilig geheugenbeheer.
+* `delta1_api_version` geeft een pointer naar een intern beheerde `CString`; niet vrijgeven.
 
 ---
 
-## 14. Beveiliging (kern)
+## 13. Repository-overzicht (`lib.rs`)
 
-* Pad-sanitatie bij file-I/O: verbied `..` path traversal; prefix alle paden met `cfg.data_root`.
-* Bestandsrechten minimaal; fail-fast bij permissieproblemen.
-* Input-validatie: schema-namen/kolommen alleen `[A-Za-z0-9_]+`.
-* Crash-isolation: geen unwrap buiten test/scope; `Result`/`Option` strikt checken.
-
----
-
-## 15. Performance-playbook
-
-* Ingest: buffer size afstemmen (64–256 KiB), lijn-gebaseerde parsing.
-* Infer: batch API; worker-pool met N = cores.
-* I/O: append-only voor logs/artefacten; lock duur minimaliseren.
-* Build: `-C lto=fat` (release), `panic=abort` in `Cargo.toml` voor cdylib.
-
-```toml
-# Cargo.toml (relevant excerpt)
-[profile.release]
-lto = true
-codegen-units = 1
-panic = "abort"
-```
-
----
-
-## 16. Teststrategie
-
-* **Unit**: elke `domain.rs`/`service.rs` met pure std tests.
-* **FFI-contract**: symbol-aanwezigheid + round-trip string alloc/free.
-* **Integratie**: ingest→train→infer met temp-directories (`std::env::temp_dir()`).
-* **Leak-check**: voor elke FFI string: alloc → `delta1_free_str`.
+`lib.rs` re-exporteert een smalle façade voor interne callers:
 
 ```rust
-#[cfg(test)]
-mod tests {
-    use super::*;
-    #[test] fn err_codes_are_stable(){ assert_eq!(DeltaCode::Ok as u32, 0); }
-}
+pub use data::service::{export_datasheet, ingest_file as core_data_ingest};
+pub use inference::service::{infer_with_ctx as core_infer_with_ctx, register_active_model};
+pub use training::service::{export_model_card, load_model as core_load_model, train as core_train};
 ```
 
----
-
-## 17. Build & Lay-out
-
-* **cdylib** output:
-
-  * Linux: `libdelta1.so`
-  * macOS: `libdelta1.dylib`
-  * Windows: `delta1.dll`
-* *Geen* `serde`, *geen* `regex`, *geen* async runtime; alles std.
+Zo kan de FFI-laag (`api::ffi`) stabiel blijven terwijl implementatiedetails per
+module evolueren.
 
 ---
 
-## 18. Publieke façade (binnen crate)
+## 14. Toekomstige uitbreidingen
 
-Alleen deze drie façade-functies worden via `lib.rs` her-geëxporteerd (intern bruikbaar én door FFI aangeroepen):
+* **Persistente repos**: koppel `DataRepo` en `ModelRepo` aan FS/DB zodra
+  retentionbeleid is uitgewerkt.
+* **Consent store**: vervang `AllowAllConsent` door een echte opslaglaag via FFI.
+* **Evaluatie**: implementeer metric- en driftberekeningen, exporteer rapporten via FFI.
+* **Observability**: breid `log_json` uit met sampling en metrics.
 
-```rust
-// lib.rs
-pub use data::service::ingest_file as core_data_ingest;
-pub use training::service::{train, load_model};
-pub use inference::service::infer as core_infer;
-```
-
----
-
-## 19. Minimale skeletimplementaties (knip-en-plak start)
-
-```rust
-// common/time.rs
-pub fn now_ms() -> u128 {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis()
-}
-
-// common/ids.rs
-pub struct SimpleHash(u32);
-impl SimpleHash {
-    pub fn new()->Self{ Self(2166136261) } // FNV basis
-    pub fn update(&mut self, bytes:&[u8]){ for b in bytes { self.0 = (self.0 ^ (*b as u32)).wrapping_mul(16777619); } }
-    pub fn finish32(&self)->u32{ self.0 }
-}
-```
-
----
-
-## 20. Migratiepad (wanneer nodig)
-
-* Module extraheren → eigen proces → netwerkcontract blijft identiek aan FFI-payloads (JSON strings).
-* De interne traits (`DataRepo`, `ModelRepo`, `InferEngine`) worden dan “drivers” naar IPC/HTTP zonder de domeinlogica te wijzigen.
-
----


### PR DESCRIPTION
## Summary
- align the top-level README with the current Rust module exports and FFI surface
- rewrite the module overview to describe the implemented contracts and error codes
- refresh the PHP FFI guide and rust-core reference with the actual delta1_* API behaviour

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d1ad4e81e88322a590c859c378d80a