### PR TITLE
Add Gate 0 intake, DPIA-lite and consent docs

### DIFF
--- a/docs/gate0-dpia-lite.md
+++ b/docs/gate0-dpia-lite.md
@@ -1,0 +1,54 @@
+# Gate 0 DPIA-lite – Delta 1 Generieke AI-assistent
+
+## 1. Verwerkingsactiviteiten
+- **Doel:** leveren van AI-ondersteuning voor medewerkers en klanten met informatievoorziening, samenvattingen en automatisering.
+- **Betrokken systemen:** AI-assistent services (`delta1_*`), CRM/ticketing, interne kennisbanken, consentstore, monitoring/logging.
+- **Gegevensbronnen:** publieke documentatie, interne beleidsdocumenten en FAQ’s, metadata van interacties, CRM-ticketdata.
+
+## 2. Categorieën persoonsgegevens
+- Identificatiegegevens: naam, e-mailadres, telefoonnummer, klantnummer.
+- Contacthistorie: ticketcontext en vrije tekst (mogelijk PII, incidenteel gevoelige data zoals gezondheid of financiën).
+- Gebruiksmetadata: tijdstip, kanaal, type vraag, tool calls.
+
+## 3. Rechtsgrond en consent
+- **Lawful basis:** contractuele noodzaak voor bestaande klanten en expliciete opt-in via CMP voor overige gebruikers.
+- **Consentbeheer:** consent-banner/opt-in beheerd via CMP (bijv. OneTrust); synchronisatie naar centrale consentstore via API-calls; AI-assistent raadpleegt store real-time of via periodieke sync.
+- **NoConsent-beleid:** `DeltaCode::NoConsent` blokkeert toegang tot interne data en levert generieke antwoorden; gemapt naar HTTP 403 met auditlogging.
+
+## 4. Risicoanalyse
+| Risico | Impact | Waarschijnlijkheid | Mitigaties |
+| --- | --- | --- | --- |
+| Onbedoelde verwerking van PII/gevoelige data via vrije tekst | Hoog | Middel | DLP-detectie, automatische redactie, verplichte HITL bij detectie, dataminimalisatie. |
+| Ongeautoriseerde toegang tot interne documenten | Hoog | Laag | Rolgebaseerde toegang, sandboxing, allowlists, rate limiting, audittrail. |
+| Datalek via logs of monitoring | Middel | Laag | Logging zonder inhoud (alleen metadata), 24-uurs purge van tijdelijke velden, encryptie in rust en transit. |
+| Onverklaarbare beslissingen / gebrek aan uitlegbaarheid | Middel | Middel | WhyLog-coverage, human override, escalatie naar HITL bij twijfel, documentatie van beslissingen. |
+| Fairness-regressie / bias | Middel | Middel | CI-gates op fairness/differential privacy, periodieke modelcard updates, monitoring van beslissingsscores. |
+| Operationele drift / modelveroudering | Middel | Middel | Continue monitoring, versiebeheer, automatische mitigaties en rollback naar veilige modellen. |
+
+## 5. Dataretentie en verwijdering
+- Ruwe logs maximaal 30 dagen; gevoelige velden zo snel mogelijk purgen, streefwaarde < 24 uur.
+- Geanonimiseerde interactiestatistieken maximaal 12 maanden voor trendanalyse.
+- Consentstatussen en audittrails worden behouden volgens wettelijke bewaartermijnen (minimaal 1 jaar, maximaal 7 jaar afhankelijk van sectorregels).
+
+## 6. Beveiligingsmaatregelen
+- Sandboxing van agent-acties en gecontroleerde toolaanroepen via ToolRegistry.
+- Rate limiting en commandbudget-controle om misbruik te voorkomen.
+- Toegangsbeheer geïntegreerd met bestaande IAM-oplossingen.
+- Monitoring op policy-overtredingen, escalaties en consent-violations.
+- Incidentresponsplan gekoppeld aan ticketingsysteem met correlatie-ID’s voor herleidbaarheid zonder inhoudelijke logging.
+
+## 7. Betrokkenenrechten
+- Ondersteuning voor inzage-, correctie- en verwijderingsverzoeken via CRM/ticketing.
+- Consentstore houdt gehashte subject-id’s bij om verzoeken efficiënt af te handelen.
+- DeltaCode-logica documenteert geweigerde verzoeken zodat het bezwaarrecht kan worden nageleefd.
+
+## 8. HITL en governance
+- Escalatiepad naar 1e lijn support en 2e lijn domeinspecialisten; eindverantwoordelijkheid bij afdelingsmanager.
+- Ticketingsysteem (Jira Service Management, ServiceNow of Zendesk) vormt de primaire tooling; specialistensystemen (ITSM, HR-portal, juridische tools) voor tweede lijn.
+- Audit trail via ticket-ID waarin AI-actie en menselijke beoordeling worden vastgelegd; versies en statuswissels worden automatisch bijgehouden.
+
+## 9. Openstaande acties voor Gate 0
+- Formele goedkeuring van DPO en CIO/CTO op dit DPIA-lite document.
+- Juridische validatie van consentmechanisme en retentiontermijnen.
+- Implementatie en test van DLP-filters op vrije tekst voordat pilot start.
+- Voorbereiden van `DeltaCode::NoConsent` testscripts en documentatie van resultaten.

--- a/docs/gate0-intakecanvas.md
+++ b/docs/gate0-intakecanvas.md
@@ -1,0 +1,64 @@
+# Gate 0 Intakecanvas – Delta 1 Generieke AI-assistent
+
+## 1. Businesscontext en doelmetrieken
+- **Use-case / probleem:** Een generieke AI-assistent die medewerkers en klanten ondersteunt met informatie, productiviteit (samenvattingen, rapporten, Q&A) en automatisering van repetitieve taken om werkdruk te verlagen en responstijd te verkorten.
+- **Doelmetrieken:**
+  - Gemiddelde responstijd < 2 seconden.
+  - Gebruikerstevredenheid (CSAT) > 80%.
+  - < 5% escalaties naar menselijke support.
+- **HITL-escalatiepaden:**
+  - 1e lijn: supportmedewerker via ticketingsysteem.
+  - 2e lijn: domeinspecialisten (IT, HR, juridisch afhankelijk van context).
+  - Verantwoordelijke eindbeslisser: afdelingsmanager.
+
+## 2. Data en acties
+- **Gegevenscategorieën:**
+  - Publieke kennis (documentatie, handleidingen).
+  - Bedrijfsinterne documenten (beleidsstukken, FAQ’s).
+  - Metadata van interacties (tijdstip, type vraag, kanaal).
+  - Persoonsgegevens via CRM/ticketing: naam, e-mailadres, telefoonnummer, klantnummer en ticketcontext (vrije tekst kan incidenteel PII bevatten).
+  - Noodscenario’s: vrije tekst kan gevoelige data (gezondheid, financiële info) bevatten.
+- **Agent-acties en tools:**
+  - Tekstanalyse en samenvatting.
+  - Toegang tot interne kennisbanken via API.
+  - Interactie met externe systemen (CRM, ticketing).
+  - Geplande toolkoppelingen via ToolRegistry met database- en HTTP-adapters.
+- **Retentiebeleid:**
+  - Ruwe logs maximaal 30 dagen.
+  - Geanonimiseerde interactiestatistieken 12 maanden.
+  - Geen blijvende opslag van gevoelige input; noodscenario’s vereisen DLP-filter en fallback naar HITL.
+
+## 3. Logging en monitoring
+- **Logging zonder inhoud:** alleen request-ID, timestamp, gebruikte tool/actie, statuscode en response-tijd.
+- **Incidentrespons:** correlatie-ID’s koppelen interacties aan CRM/ticketing waar inhoud al beveiligd is.
+- **Prestatie- en veiligheidsmetriek:** monitor commandbudget, latenties per tool-call, geblokkeerde policy-overtredingen, HITL-escalaties, consent-violations.
+
+## 4. Privacy, risico’s en mitigaties
+- **Belangrijkste risico’s:** onbedoelde verwerking van persoonsgegevens, ongeautoriseerde toegang, tool-misbruik, datalek via logs, onverklaarbare beslissingen, fairness-regressie.
+- **Mitigaties:** dataminimalisatie, logging zonder inhoud, toegangsbeheer, monitoring, DLP-filter op vrije tekst, sandboxing en allowlists voor tools, rate limiting, verplicht WhyLog-uitleg bij hoge risico’s, 24-uurs purge van tijdelijke velden, CI-gates voor fairness/DP.
+- **Toestemming:** expliciete opt-in via CMP; consentstatus beschikbaar via centrale consentstore.
+
+## 5. Purpose, consent en DeltaCode
+- **Purpose-id’s:**
+  - `AI_Assist_Generic_Info` (nieuw).
+  - `AI_Assist_Internal_Productivity` (uitbreiding bestaand).
+- **Consentflow:** standaard opt-in voor eindgebruikers, consent vastgelegd via CMP en gesynchroniseerd met consentstore; AI-assistent raadpleegt store real-time of via sync.
+- **NoConsent-handling:** `DeltaCode::NoConsent` leidt tot generieke antwoorden zonder interne data en map naar HTTP 403.
+
+## 6. Risicoklassen en externe communicatie
+- **Risiconiveaus:**
+  - Laag: feitelijke informatie, samenvattingen.
+  - Midden: beslissingsondersteuning (HR, IT advies).
+  - Hoog: juridische of medische context → altijd HITL.
+- **Extern contract:** DeltaCode→HTTP mapping (OK→200, HITL nodig→202, NoConsent→403) aangevuld met bestaande mappings (422, 404, 400, 500) voor fouten.
+- **Compliance:** GDPR, EU AI Act (transparantie, risicobeoordeling), sectorregels (zorg, finance).
+
+## 7. Randvoorwaarden en afhankelijkheden
+- **Stakeholders Gate 0:** CIO/CTO, DPO, afdelingsmanagers.
+- **Benodigde documentatie:** Intakecanvas, DPIA-lite, escalerende HITL-protocollen, purpose-registraties, DeltaCode::NoConsent tests.
+- **Afhankelijkheden:** API-toegang tot interne systemen, juridische goedkeuring consentmechanisme, resources voor modelmonitoring, productieklare consentstore in plaats van `AllowAllConsent`.
+
+## 8. Volgende stappen
+- Finaliseer DPIA-lite met bovenstaande risico’s en mitigaties.
+- Beschrijf HITL-escapepaden in detail en plan training voor 1e/2e lijn.
+- Automatische DLP en consentchecks implementeren en testen inclusief `NoConsent`-scenario.

--- a/docs/gate0-purpose-consent.md
+++ b/docs/gate0-purpose-consent.md
@@ -1,0 +1,44 @@
+# Gate 0 Purpose- en Consentregistratie – Delta 1 Generieke AI-assistent
+
+## 1. Overzicht
+Deze notitie documenteert de purpose-id’s, consentflows en testscenario’s die nodig zijn om Gate 0 af te ronden voor de generieke AI-assistent.
+
+## 2. Purpose-id’s
+| Purpose-id | Type | Beschrijving | Datacategorieën | Verantwoordelijke |
+| --- | --- | --- | --- | --- |
+| `AI_Assist_Generic_Info` | Nieuw | Leveren van generieke antwoorden en publieke documentatie aan gebruikers zonder interne context. | Publieke kennis, metadata van interacties. | Product owner AI-assistent. |
+| `AI_Assist_Internal_Productivity` | Uitbreiding | Ondersteunen van medewerkers bij interne processen (samenvattingen, rapportages, Q&A) op basis van interne documenten. | Interne beleidsstukken, FAQ’s, CRM-ticketcontext, metadata. | Afdelingsmanager / proceseigenaren. |
+
+## 3. Consentbeheer
+- **CMP-integratie:** Consent-banner/opt-in wordt beheerd via bestaand CMP (OneTrust of interne module).
+- **Synchronisatie:** CMP schrijft consentstatus naar centrale consentstore via API; opslag bevat `subject_id` (gehasht), `purpose_id`, status, timestamp en bron.
+- **AI-consumptie:** AI-assistent raadpleegt consentstore real-time (API) of via periodieke sync; fallback-cache maximaal 24 uur geldig.
+- **Audit:** Elke wijziging in consentstatus wordt gelogd met request-ID en ticket-ID voor traceerbaarheid.
+
+## 4. DeltaCode mapping en testen
+| DeltaCode | HTTP-status | Beschrijving | Actie |
+| --- | --- | --- | --- |
+| `Ok` | 200 | Volledige functionaliteit toegestaan. | Normale afhandeling en logging zonder inhoud. |
+| `HitlRequired` | 202 | Menselijke beoordeling vereist. | Maak/actualiseer ticket; wijs toe aan 1e lijn support. |
+| `NoConsent` | 403 | Geen geldige consent voor aangevraagde purpose. | Lever alleen generieke antwoorden, log weigering en ticket voor follow-up. |
+| `InvalidPurpose` | 422 | Purpose-id niet erkend. | Fout teruggeven, escaleer naar product owner. |
+| `NotFound` | 404 | Gevraagde bron niet beschikbaar. | Meld aan gebruiker, log voor incidentanalyse. |
+| `InvalidRequest` | 400 | Ongeldige input. | Geef fout terug, overweeg DLP-scan. |
+| `InternalError` | 500 | Onverwachte fout. | Escalatie naar 2e lijn, log met correlatie-ID. |
+
+- **Testscenario’s:**
+  1. Consent aanwezig voor beide purpose-id’s → verwachte `DeltaCode::Ok` en HTTP 200.
+  2. Consent ontbreekt of ingetrokken → `DeltaCode::NoConsent`, HTTP 403, generieke fallback zonder interne data.
+  3. Purpose onbekend → `DeltaCode::InvalidPurpose`, HTTP 422, auditverplichting.
+  4. HITL-trigger (gevoelige context) → `DeltaCode::HitlRequired`, HTTP 202 met ticketaanmaak.
+- **Meetpunten:** aantal NoConsent-gevallen, responstijd CMP-check, succesratio van consent-sync jobs.
+
+## 5. HITL- en auditkoppeling
+- **Ticketing:** 1e lijn verwerkt escalaties in systeem zoals Jira Service Management, ServiceNow of Zendesk; 2e lijn in specialistische systemen (ITSM, HR, juridisch).
+- **Audit trail:** Elke escalatie krijgt ticket-ID met log van AI-actie, consentstatus en menselijke beslissing; wijzigingen worden automatisch vastgelegd door ticketingsysteem.
+
+## 6. Openstaande acties
+- Implementatie van productieklare consentstore (vervang `AllowAllConsent`).
+- Validatie van CMP-API-koppeling en fallbackmechanisme.
+- Documenteer en automatiseer `DeltaCode::NoConsent` testscripts.
+- Bevestig bewaartermijnen voor consentlogs conform sectorregels (1–7 jaar).


### PR DESCRIPTION
## Summary
- document the Gate 0 intakecanvas for the generic AI assistant, covering business context, data flows, risk levels and dependencies
- capture a DPIA-lite focused on datasets, lawful basis, risk mitigations and retention rules for the assistant
- register the required purposes, consent flow design and DeltaCode mappings, including HITL and test scenarios

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1b280f0c883229924e91df27608cf