### PR TITLE
Document Gate 0 flows without external integrations

### DIFF
--- a/docs/gate0-dpia-lite.md
+++ b/docs/gate0-dpia-lite.md
@@ -1,0 +1,55 @@
+# Gate 0 DPIA-lite – Delta 1 Generieke AI-assistent
+
+## 1. Verwerkingsactiviteiten
+- **Doel:** leveren van AI-ondersteuning voor medewerkers en klanten met informatievoorziening, samenvattingen en automatisering.
+- **Betrokken systemen:** AI-assistent services (`delta1_*`), interne service-portal, interne kennisbanken, consentstore, monitoring/logging.
+- **Gegevensbronnen:** publieke documentatie, interne beleidsdocumenten en FAQ’s, metadata van interacties, invoer uit de interne service-portal.
+- **Integratiebeleid:** alle componenten draaien binnen de Delta 1-omgeving; er worden geen externe SaaS-diensten gekoppeld.
+
+## 2. Categorieën persoonsgegevens
+- Identificatiegegevens: naam, e-mailadres, telefoonnummer, klantnummer.
+- Contacthistorie: aanvraagcontext en vrije tekst (mogelijk PII, incidenteel gevoelige data zoals gezondheid of financiën).
+- Gebruiksmetadata: tijdstip, kanaal, type vraag, tool calls.
+
+## 3. Rechtsgrond en consent
+- **Lawful basis:** contractuele noodzaak voor bestaande klanten en expliciete opt-in via de interne consentmodule voor overige gebruikers.
+- **Consentbeheer:** consent-banner/opt-in beheerd via de interne consentmodule; synchronisatie naar centrale consentstore via interne API-calls; AI-assistent raadpleegt store real-time of via periodieke sync.
+- **NoConsent-beleid:** `DeltaCode::NoConsent` blokkeert toegang tot interne data en levert generieke antwoorden; gemapt naar HTTP 403 met auditlogging.
+
+## 4. Risicoanalyse
+| Risico | Impact | Waarschijnlijkheid | Mitigaties |
+| --- | --- | --- | --- |
+| Onbedoelde verwerking van PII/gevoelige data via vrije tekst | Hoog | Middel | DLP-detectie, automatische redactie, verplichte HITL bij detectie, dataminimalisatie. |
+| Ongeautoriseerde toegang tot interne documenten | Hoog | Laag | Rolgebaseerde toegang, sandboxing, allowlists, rate limiting, audittrail. |
+| Datalek via logs of monitoring | Middel | Laag | Logging zonder inhoud (alleen metadata), 24-uurs purge van tijdelijke velden, encryptie in rust en transit. |
+| Onverklaarbare beslissingen / gebrek aan uitlegbaarheid | Middel | Middel | WhyLog-coverage, human override, escalatie naar HITL bij twijfel, documentatie van beslissingen. |
+| Fairness-regressie / bias | Middel | Middel | CI-gates op fairness/differential privacy, periodieke modelcard updates, monitoring van beslissingsscores. |
+| Operationele drift / modelveroudering | Middel | Middel | Continue monitoring, versiebeheer, automatische mitigaties en rollback naar veilige modellen. |
+
+## 5. Dataretentie en verwijdering
+- Ruwe logs maximaal 30 dagen; gevoelige velden zo snel mogelijk purgen, streefwaarde < 24 uur.
+- Geanonimiseerde interactiestatistieken maximaal 12 maanden voor trendanalyse.
+- Consentstatussen en audittrails worden behouden volgens wettelijke bewaartermijnen (minimaal 1 jaar, maximaal 7 jaar afhankelijk van sectorregels).
+
+## 6. Beveiligingsmaatregelen
+- Sandboxing van agent-acties en gecontroleerde toolaanroepen via ToolRegistry.
+- Rate limiting en commandbudget-controle om misbruik te voorkomen.
+- Toegangsbeheer geïntegreerd met bestaande IAM-oplossingen.
+- Monitoring op policy-overtredingen, escalaties en consent-violations.
+- Incidentresponsplan gekoppeld aan de interne operations-console met correlatie-ID’s voor herleidbaarheid zonder inhoudelijke logging.
+
+## 7. Betrokkenenrechten
+- Ondersteuning voor inzage-, correctie- en verwijderingsverzoeken via de interne service-portal.
+- Consentstore houdt gehashte subject-id’s bij om verzoeken efficiënt af te handelen.
+- DeltaCode-logica documenteert geweigerde verzoeken zodat het bezwaarrecht kan worden nageleefd.
+
+## 8. HITL en governance
+- Escalatiepad naar 1e lijn support en 2e lijn domeinspecialisten; eindverantwoordelijkheid bij afdelingsmanager.
+- De interne operations-console vormt de primaire tooling; interne specialistische modules (ITSM, HR-portaal, juridische workflow) ondersteunen de tweede lijn.
+- Audit trail via aanvraag-ID waarin AI-actie en menselijke beoordeling worden vastgelegd; versies en statuswissels worden automatisch bijgehouden.
+
+## 9. Openstaande acties voor Gate 0
+- Formele goedkeuring van DPO en CIO/CTO op dit DPIA-lite document.
+- Juridische validatie van consentmechanisme en retentiontermijnen.
+- Implementatie en test van DLP-filters op vrije tekst voordat pilot start.
+- Voorbereiden van `DeltaCode::NoConsent` testscripts en documentatie van resultaten.

--- a/docs/gate0-intakecanvas.md
+++ b/docs/gate0-intakecanvas.md
@@ -1,0 +1,65 @@
+# Gate 0 Intakecanvas – Delta 1 Generieke AI-assistent
+
+## 1. Businesscontext en doelmetrieken
+- **Use-case / probleem:** Een generieke AI-assistent die medewerkers en klanten ondersteunt met informatie, productiviteit (samenvattingen, rapporten, Q&A) en automatisering van repetitieve taken om werkdruk te verlagen en responstijd te verkorten.
+- **Doelmetrieken:**
+  - Gemiddelde responstijd < 2 seconden.
+  - Gebruikerstevredenheid (CSAT) > 80%.
+  - < 5% escalaties naar menselijke support.
+- **HITL-escalatiepaden:**
+  - 1e lijn: supportmedewerker via de interne operations-console.
+  - 2e lijn: domeinspecialisten (IT, HR, juridisch afhankelijk van context) binnen hetzelfde platform.
+  - Verantwoordelijke eindbeslisser: afdelingsmanager.
+
+## 2. Data en acties
+- **Gegevenscategorieën:**
+  - Publieke kennis (documentatie, handleidingen).
+  - Bedrijfsinterne documenten (beleidsstukken, FAQ’s).
+  - Metadata van interacties (tijdstip, type vraag, kanaal).
+  - Persoonsgegevens die gebruikers zelf invoeren in de interne service-portal: naam, e-mailadres, telefoonnummer, medewerker- of klantnummer en context (vrije tekst kan incidenteel PII bevatten).
+  - Noodscenario’s: vrije tekst kan gevoelige data (gezondheid, financiële info) bevatten.
+- **Agent-acties en tools:**
+  - Tekstanalyse en samenvatting.
+  - Toegang tot interne kennisbanken via interne API’s.
+  - Interactie met interne workflow-services voor opvolging en logging.
+  - Geplande toolkoppelingen via ToolRegistry met uitsluitend interne database- en HTTP-adapters.
+  - Alle koppelingen blijven binnen Delta 1; er zijn geen externe SaaS-integraties.
+- **Retentiebeleid:**
+  - Ruwe logs maximaal 30 dagen.
+  - Geanonimiseerde interactiestatistieken 12 maanden.
+  - Geen blijvende opslag van gevoelige input; noodscenario’s vereisen DLP-filter en fallback naar HITL.
+
+## 3. Logging en monitoring
+- **Logging zonder inhoud:** alleen request-ID, timestamp, gebruikte tool/actie, statuscode en response-tijd.
+- **Incidentrespons:** correlatie-ID’s koppelen interacties aan de interne service-portal waar inhoud al beveiligd is.
+- **Prestatie- en veiligheidsmetriek:** monitor commandbudget, latenties per tool-call, geblokkeerde policy-overtredingen, HITL-escalaties, consent-violations.
+
+## 4. Privacy, risico’s en mitigaties
+- **Belangrijkste risico’s:** onbedoelde verwerking van persoonsgegevens, ongeautoriseerde toegang, tool-misbruik, datalek via logs, onverklaarbare beslissingen, fairness-regressie.
+- **Mitigaties:** dataminimalisatie, logging zonder inhoud, toegangsbeheer, monitoring, DLP-filter op vrije tekst, sandboxing en allowlists voor tools, rate limiting, verplicht WhyLog-uitleg bij hoge risico’s, 24-uurs purge van tijdelijke velden, CI-gates voor fairness/DP.
+- **Toestemming:** expliciete opt-in via de interne consentmodule; consentstatus beschikbaar via centrale consentstore.
+
+## 5. Purpose, consent en DeltaCode
+- **Purpose-id’s:**
+  - `AI_Assist_Generic_Info` (nieuw).
+  - `AI_Assist_Internal_Productivity` (uitbreiding bestaand).
+- **Consentflow:** standaard opt-in voor eindgebruikers, consent vastgelegd via interne consentmodule en gesynchroniseerd met consentstore; AI-assistent raadpleegt store real-time of via sync.
+- **NoConsent-handling:** `DeltaCode::NoConsent` leidt tot generieke antwoorden zonder interne data en map naar HTTP 403.
+
+## 6. Risicoklassen en externe communicatie
+- **Risiconiveaus:**
+  - Laag: feitelijke informatie, samenvattingen.
+  - Midden: beslissingsondersteuning (HR, IT advies).
+  - Hoog: juridische of medische context → altijd HITL.
+- **Extern contract:** DeltaCode→HTTP mapping (OK→200, HITL nodig→202, NoConsent→403) aangevuld met bestaande mappings (422, 404, 400, 500) voor fouten.
+- **Compliance:** GDPR, EU AI Act (transparantie, risicobeoordeling), sectorregels (zorg, finance).
+
+## 7. Randvoorwaarden en afhankelijkheden
+- **Stakeholders Gate 0:** CIO/CTO, DPO, afdelingsmanagers.
+- **Benodigde documentatie:** Intakecanvas, DPIA-lite, escalerende HITL-protocollen, purpose-registraties, DeltaCode::NoConsent tests.
+- **Afhankelijkheden:** interne API-toegang binnen Delta 1, juridische goedkeuring consentmechanisme, resources voor modelmonitoring, productieklare consentstore in plaats van `AllowAllConsent`.
+
+## 8. Volgende stappen
+- Finaliseer DPIA-lite met bovenstaande risico’s en mitigaties.
+- Beschrijf HITL-escapepaden in detail en plan training voor 1e/2e lijn.
+- Automatische DLP en consentchecks implementeren en testen inclusief `NoConsent`-scenario.

--- a/docs/gate0-purpose-consent.md
+++ b/docs/gate0-purpose-consent.md
@@ -1,0 +1,45 @@
+# Gate 0 Purpose- en Consentregistratie – Delta 1 Generieke AI-assistent
+
+## 1. Overzicht
+Deze notitie documenteert de purpose-id’s, consentflows en testscenario’s die nodig zijn om Gate 0 af te ronden voor de generieke AI-assistent.
+
+## 2. Purpose-id’s
+| Purpose-id | Type | Beschrijving | Datacategorieën | Verantwoordelijke |
+| --- | --- | --- | --- | --- |
+| `AI_Assist_Generic_Info` | Nieuw | Leveren van generieke antwoorden en publieke documentatie aan gebruikers zonder interne context. | Publieke kennis, metadata van interacties. | Product owner AI-assistent. |
+| `AI_Assist_Internal_Productivity` | Uitbreiding | Ondersteunen van medewerkers bij interne processen (samenvattingen, rapportages, Q&A) op basis van interne documenten. | Interne beleidsstukken, FAQ’s, aanvraagcontext uit de interne portal, metadata. | Afdelingsmanager / proceseigenaren. |
+
+## 3. Consentbeheer
+- **Consentbeheer:** Consent-banner/opt-in wordt beheerd via de interne consentmodule.
+- **Synchronisatie:** De consentmodule schrijft consentstatus naar de centrale consentstore via interne API; opslag bevat `subject_id` (gehasht), `purpose_id`, status, timestamp en bron.
+- **AI-consumptie:** AI-assistent raadpleegt consentstore real-time (API) of via periodieke sync; fallback-cache maximaal 24 uur geldig.
+- **Audit:** Elke wijziging in consentstatus wordt gelogd met request-ID en aanvraag-ID voor traceerbaarheid.
+- **Integratiebeleid:** er worden geen externe consent- of CMP-diensten gekoppeld; alles blijft binnen Delta 1.
+
+## 4. DeltaCode mapping en testen
+| DeltaCode | HTTP-status | Beschrijving | Actie |
+| --- | --- | --- | --- |
+| `Ok` | 200 | Volledige functionaliteit toegestaan. | Normale afhandeling en logging zonder inhoud. |
+| `HitlRequired` | 202 | Menselijke beoordeling vereist. | Maak/actualiseer interne aanvraag; wijs toe aan 1e lijn support. |
+| `NoConsent` | 403 | Geen geldige consent voor aangevraagde purpose. | Lever alleen generieke antwoorden, log weigering en interne opvolgtaak voor follow-up. |
+| `InvalidPurpose` | 422 | Purpose-id niet erkend. | Fout teruggeven, escaleer naar product owner. |
+| `NotFound` | 404 | Gevraagde bron niet beschikbaar. | Meld aan gebruiker, log voor incidentanalyse. |
+| `InvalidRequest` | 400 | Ongeldige input. | Geef fout terug, overweeg DLP-scan. |
+| `InternalError` | 500 | Onverwachte fout. | Escalatie naar 2e lijn, log met correlatie-ID. |
+
+- **Testscenario’s:**
+  1. Consent aanwezig voor beide purpose-id’s → verwachte `DeltaCode::Ok` en HTTP 200.
+  2. Consent ontbreekt of ingetrokken → `DeltaCode::NoConsent`, HTTP 403, generieke fallback zonder interne data.
+  3. Purpose onbekend → `DeltaCode::InvalidPurpose`, HTTP 422, auditverplichting.
+  4. HITL-trigger (gevoelige context) → `DeltaCode::HitlRequired`, HTTP 202 met interne aanvraag en toewijzing.
+- **Meetpunten:** aantal NoConsent-gevallen, responstijd van de consentmodule-check, succesratio van consent-sync jobs.
+
+## 5. HITL- en auditkoppeling
+- **Operations-console:** 1e lijn verwerkt escalaties in de interne console; 2e lijn gebruikt interne specialistische modules (ITSM, HR, juridisch).
+- **Audit trail:** Elke escalatie krijgt aanvraag-ID met log van AI-actie, consentstatus en menselijke beslissing; wijzigingen worden automatisch vastgelegd binnen het platform.
+
+## 6. Openstaande acties
+- Implementatie van productieklare consentstore (vervang `AllowAllConsent`).
+- Validatie van interne consent-API-koppeling en fallbackmechanisme.
+- Documenteer en automatiseer `DeltaCode::NoConsent` testscripts.
+- Bevestig bewaartermijnen voor consentlogs conform sectorregels (1–7 jaar).


### PR DESCRIPTION
## Summary
- update the Gate 0 intakecanvas to route data capture, tooling and consent checks exclusively via internal Delta 1 services
- revise the Gate 0 DPIA-lite so the processing description, mitigation measures and governance reference only internal portals and consoles
- align the Gate 0 purpose/consent notes with the internal consent module, internal HITL console and follow-up workflows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1b280f0c883229924e91df27608cf